### PR TITLE
Fix for OAuth Client module

### DIFF
--- a/docs/wizard/config/config.js
+++ b/docs/wizard/config/config.js
@@ -108,7 +108,7 @@ export default {
                 'name': 'OAuth Client',
                 'description': 'Generated Client that\'s passed to the App Backend',
                 'roles': ['Role'],
-                'authorizedGrantType': 'CLIENT_CREDENTIALS',
+                'authorizedGrantType': 'CLIENT-CREDENTIALS',
                 /** NOTE: 
                  * If you want to learn how you can send the created credentials back to your system,
                  * Please read about the Post Custom Setup module here:

--- a/docs/wizard/config/sample-provisioning-info.js
+++ b/docs/wizard/config/sample-provisioning-info.js
@@ -309,7 +309,7 @@ let sample = {
             'name': 'OAuth Client',
             'description': 'Generated Client that\'s passed to the App Backend',
             'roles': ['Admin'],
-            'authorizedGrantType': 'CLIENT_CREDENTIALS',
+            'authorizedGrantType': 'CLIENT-CREDENTIALS',
             'accessTokenValiditySeconds': 86400,
             'finally': function (installedData) {
                 return new Promise((resolve, reject) => {

--- a/docs/wizard/scripts/modules/oauth-client.js
+++ b/docs/wizard/scripts/modules/oauth-client.js
@@ -69,7 +69,7 @@ async function create(logFunc, data) {
             accessTokenValiditySeconds: oauth.accessTokenValiditySeconds || 86400
         };
 
-        if (oauth.authorizedGrantType === 'CLIENT_CREDENTIALS') {
+        if (oauth.authorizedGrantType === 'CLIENT-CREDENTIALS') {
             oauthClient.roleIds = [employeeRole.id];
         } else {
             oauthClient.registeredRedirectUri = oauth.registeredRedirectUri || ['https://replace_this_url/some_path/index.html'];
@@ -108,7 +108,7 @@ async function configure(logFunc, installedData, userId) {
 
     Object.keys(oauthData).forEach((oauthKey) => {
         let oauth = oauthData[oauthKey];
-        if (oauth.authorizedGrantType === 'CLIENT_CREDENTIALS') {
+        if (oauth.authorizedGrantType === 'CLIENT-CREDENTIALS') {
             let promise = new Promise((resolve, reject) => {
                 let oauthInstall = config.provisioningInfo['oauth-client']
                     .find((info) => info.name == oauthKey);


### PR DESCRIPTION
Fixing an error in OAuth Client module and config.js when using Client Credentials Grant.
The module was leveraging a wrong keyname 'CLIENT_CREDENTIALS' for the grant type. It must be 'CLIENT-CREDENTIALS' (updated in config.js and in oauth-client.js).